### PR TITLE
Handle results that have no mp4

### DIFF
--- a/src/features/gifs/Gif/Gif.tsx
+++ b/src/features/gifs/Gif/Gif.tsx
@@ -21,11 +21,12 @@ interface LoadedGif {
 
 // preload the image/video and choose the optimal format
 const load = async (source: ImageAllTypes): Promise<LoadedGif> => {
+  const defaultSource = source.mp4 ? source.mp4 : source.webp;
   let image = {
-    src: source.mp4,
+    src: defaultSource,
     format: GifFormat.Video
   };
-  if (source.webp_size < source.mp4_size && (await supportsWebp())) {
+  if (source.mp4 && source.webp_size < source.mp4_size && (await supportsWebp())) {
     image = {
       src: source.webp,
       format: GifFormat.Image


### PR DESCRIPTION
In a recent project we found a weird error where fetch was being called with undefined as the argument.
This was because some of the results had webp but no mp4 - we found that some of the results for "oi..." would cause the error, as two results were webp only.

This PR is only a suggestion, but a possible solution.